### PR TITLE
fixed typeerror for binary command

### DIFF
--- a/cogs/cmds/translate.py
+++ b/cogs/cmds/translate.py
@@ -7,7 +7,7 @@ class Translate(commands.Cog, name="Translate"):
 
     @commands.command(name="binary", aliases=["ttb"], description="Translate a text to binary.")
     async def _binary(self, ctx, *, text):
-        binary = ' '.join(map(bin, bytearray(text)))
+        binary = ' '.join(map(lambda x: bin(x)[2:], bytearray(text, 'utf-8')))
         await ctx.send(str(binary))
 
 


### PR DESCRIPTION
When using the t.binary command an error is raised, TypeError: string argument without an encoding, because the bytearray function is not being passed an encoding. This error is fixed by adding the 'utf-8' encoding.

I made the bytearray map to a lambda function so it removes the 'b0' from the output.

Instead of the output being:
 '0b1101000 0b1100101 0b1101100 0b1101100 0b1101111' 
it will be:
 '1101000 1100101 1101100 1101100 1101111'
with bin(x)[2:]
